### PR TITLE
enforcing-authentication-on-all-API-routes

### DIFF
--- a/client/src/components/NorthAmericaMapModal.jsx
+++ b/client/src/components/NorthAmericaMapModal.jsx
@@ -1,11 +1,9 @@
 // client/src/components/NorthAmericaMapModal.jsx
 import { useEffect, useMemo, useState } from "react";
 import Plot from "react-plotly.js";
+import { apiGet } from "../api.js";
 
 export default function NorthAmericaMapModal({ open, onClose }) {
-  const API_BASE =
-    import.meta.env.VITE_API_BASE_URL || "http://localhost:3001";
-
   const [customers, setCustomers] = useState([]);
   const [subscriptions, setSubscriptions] = useState([]);
   const [packages, setPackages] = useState([]);
@@ -107,30 +105,11 @@ export default function NorthAmericaMapModal({ open, onClose }) {
       setPointsErr("");
 
       try {
-        const [customersRes, subscriptionsRes, packagesRes] = await Promise.all([
-          fetch(`${API_BASE}/api/customers`),
-          fetch(`${API_BASE}/api/subscriptions`),
-          fetch(`${API_BASE}/api/packages`),
+        const [customersJson, subscriptionsJson, packagesJson] = await Promise.all([
+          apiGet("/api/customers"),
+          apiGet("/api/subscriptions"),
+          apiGet("/api/packages"),
         ]);
-
-        if (!customersRes.ok) {
-          throw new Error(`Failed to load customers (HTTP ${customersRes.status})`);
-        }
-        if (!subscriptionsRes.ok) {
-          throw new Error(
-            `Failed to load subscriptions (HTTP ${subscriptionsRes.status})`
-          );
-        }
-        if (!packagesRes.ok) {
-          throw new Error(`Failed to load packages (HTTP ${packagesRes.status})`);
-        }
-
-        const [customersJson, subscriptionsJson, packagesJson] =
-          await Promise.all([
-            customersRes.json(),
-            subscriptionsRes.json(),
-            packagesRes.json(),
-          ]);
 
         if (cancelled) return;
 
@@ -168,7 +147,7 @@ export default function NorthAmericaMapModal({ open, onClose }) {
     return () => {
       cancelled = true;
     };
-  }, [open, API_BASE]);
+  }, [open]);
 
   const filterButtons = useMemo(() => {
     const packageButtons = packages

--- a/data/db-info/db_schema.json
+++ b/data/db-info/db_schema.json
@@ -504,6 +504,6 @@
   ],
   "meta": {
     "schema_path": "/app/prisma/schema.prisma",
-    "generated_at_utc": "2026-04-13T06:38:38.672575+00:00"
+    "generated_at_utc": "2026-04-13T07:15:12.360501+00:00"
   }
 }

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -30,14 +30,21 @@ app.use((req, _res, next) => {
   next();
 });
 
-// Public static files
+// ── Public static files (no auth required) ──────────────────────────────────
 app.use("/exports", express.static("/app/exports"));
 app.use("/snapshots", express.static("/app/client/public/snapshots"));
 
-// Public health check
-app.get("/api/health", (req, res) => res.json({ ok: true }));
+// ── Public endpoints (no auth required) ─────────────────────────────────────
+app.get("/api/health", (_req, res) => res.json({ ok: true }));
 
-// Public routes
+// ── Auth guard — everything mounted below this line requires a valid Firebase
+//    token. In test mode the guard is skipped so tests can run without
+//    credentials. ──────────────────────────────────────────────────────────
+if (process.env.NODE_ENV !== "test") {
+  app.use("/api", requireFirebaseAuth);
+}
+
+// ── Protected routes ─────────────────────────────────────────────────────────
 app.use("/api/analytics", analyticsRoutes);
 app.use("/api/data", dataRoutes);
 app.use("/api/nightly", nightlyRoutes);
@@ -49,12 +56,7 @@ app.use("/api/packages", packagesRouter);
 app.use("/api/subscriptions", subscriptionsRouter);
 app.use("/api/payments", paymentsRouter);
 
-// Protect everything below this line
-if (process.env.NODE_ENV !== "test") {
-  app.use("/api", requireFirebaseAuth);
-}
-
-// Global error handler
+// ── Global error handler ─────────────────────────────────────────────────────
 app.use((err, _req, res, _next) => {
   log.error("Unhandled error", err);
   res.status(500).json({ error: "Internal server error" });


### PR DESCRIPTION
## Summary

Resolved by correcting the middleware mount order in `server/src/app.js` and
replacing unauthenticated `fetch()` calls in `NorthAmericaMapModal.jsx` with
the authenticated `apiGet` helper. The application now enforces authentication
on every API endpoint as intended.

## What was wrong

### Server — auth middleware mounted after all routes

Express processes middleware and routes in the order they are registered. A
middleware registered after a route will never execute for that route because
the route has already sent a response by the time the middleware is reached.

In the original `app.js`, all ten route handlers were registered first, and
`requireFirebaseAuth` was registered last, under a comment that read
`// Protect everything below this line`. Nothing below that line was a route.
The middleware ran for no requests at all.

The practical consequence was that every endpoint the server exposed — customer
records, payment history, subscription data, analytics queries, and the admin
seed endpoint that can wipe and repopulate the entire database — was accessible
to anyone who knew the server address, with no token, no login, and no
authentication of any kind.

### Client — map modal used unauthenticated fetch()

When the server-side fix was applied and authentication started being enforced,
a second problem became visible. The "Our Clients" map modal
(`NorthAmericaMapModal.jsx`) was calling three API endpoints using bare
`fetch()`:

```js
fetch(`${API_BASE}/api/customers`)
fetch(`${API_BASE}/api/subscriptions`)
fetch(`${API_BASE}/api/packages`)
```

These calls carried no `Authorization` header and no Firebase token. Every
other data fetch in the application uses `apiGet` from `api.js`, which reads
the current user's Firebase token and attaches it as a `Bearer` header
automatically. The map modal was the only component that bypassed this pattern,
and the symptom was a `Map data error: Failed to load customers (HTTP 401)`
error visible in the UI as soon as the server started correctly rejecting
unauthenticated requests.

---

## What was changed

### `server/src/app.js`

The auth middleware was moved above all route registrations. The file now has
four clearly separated sections, each labelled with a comment:

```js
// ── Public static files (no auth required)
app.use("/exports", express.static(...));
app.use("/snapshots", express.static(...));

// ── Public endpoints (no auth required)
app.get("/api/health", ...);

// ── Auth guard — everything below requires a valid Firebase token
if (process.env.NODE_ENV !== "test") {
  app.use("/api", requireFirebaseAuth);
}

// ── Protected routes
app.use("/api/customers", customersRouter);
app.use("/api/payments", paymentsRouter);
// ... all other routes
```

The only endpoints that remain public are the health check (used by Docker
Compose to determine when the container is ready), and the static file paths
for chart exports and snapshots. Everything else requires a valid Firebase
token.

The test-mode bypass (`NODE_ENV !== "test"`) was kept in the same position so
the existing test suite continues to run without Firebase credentials.

### `client/src/components/NorthAmericaMapModal.jsx`

The three bare `fetch()` calls were replaced with `apiGet` from `../api.js`:

```js
// Before — no auth header, rejected with 401
const [customersRes, subscriptionsRes, packagesRes] = await Promise.all([
  fetch(`${API_BASE}/api/customers`),
  fetch(`${API_BASE}/api/subscriptions`),
  fetch(`${API_BASE}/api/packages`),
]);

// After — authenticated, consistent with the rest of the client
const [customersJson, subscriptionsJson, packagesJson] = await Promise.all([
  apiGet("/api/customers"),
  apiGet("/api/subscriptions"),
  apiGet("/api/packages"),
]);
```

The manual `res.ok` checks and `res.json()` calls were also removed because
`apiGet` handles both — it throws on non-2xx responses and returns the parsed
JSON body. The now-unused `API_BASE` constant and its entry in the `useEffect`
dependency array were removed as cleanup.

---

## Why the app is better

**Authentication is now actually enforced.** Before this fix, the
`requireFirebaseAuth` middleware existed, was correctly implemented, and would
have done its job — if it had ever been called. Moving it above the routes
means it now runs on every request to every `/api/*` path that is not
explicitly listed as public. The security model that was described in comments
and implied by the middleware's existence is now the security model that
actually operates at runtime.

**The admin endpoints are no longer open to the internet.** `POST
/api/admin/seed` with `reset: true` would have wiped the entire database for
any caller. `POST /api/admin/repopulate` would have triggered a full reset.
These are now protected by the same Firebase token verification as every other
endpoint.

**The client is internally consistent.** Every component in the application
now uses the same authenticated data-fetching pattern. There is no longer a
component that works in development (where the server was unprotected) but
breaks in a correctly configured environment. The map modal uses `apiGet`
for the same reason every other component does — it is the single place in
the codebase that knows how to attach a token to an outgoing request.

**The mount order is now self-documenting.** The four labelled sections in
`app.js` make the security boundary visible and explicit. A developer adding a
new route in the future can see immediately which section it belongs in, and
placing it in the wrong section — above the auth guard — would be a deliberate
act rather than an accidental one.

Closes #119 